### PR TITLE
S6R10 fixes

### DIFF
--- a/BDArmory/Ammo/PooledBullet.cs
+++ b/BDArmory/Ammo/PooledBullet.cs
@@ -1396,7 +1396,7 @@ namespace BDArmory.Bullets
             if (!partsHit.Contains(hitPart)) partsHit.Add(hitPart);
             //bullet should not go any further if moving too slowly after hit
             //smaller caliber rounds would be too deformed to do any further damage
-            if (currentVelocity.magnitude <= 100 && hasPenetrated)
+            if (hasPenetrated && (currentVelocity - hitPartVelocity).sqrMagnitude < 1e4f)
             {
                 if (BDArmorySettings.DEBUG_WEAPONS)
                 {

--- a/BDArmory/Control/BDAirspeedControl.cs
+++ b/BDArmory/Control/BDAirspeedControl.cs
@@ -653,6 +653,7 @@ namespace BDArmory.Control
 
             for (int i = 0; i < rcsEngines.Count; i++)
             {
+                if (rcsEngines[i] == null) continue;
                 float giveThrust = 0;
                 float forwardDist = Vector3.Dot(rcsEngines[i].transform.position - vessel.CoM, vessel.ReferenceTransform.up);
                 bool rearMount = forwardDist < 0;

--- a/BDArmory/Weapons/ModuleWeapon.cs
+++ b/BDArmory/Weapons/ModuleWeapon.cs
@@ -2589,7 +2589,7 @@ namespace BDArmory.Weapons
                                 if (hitPart != null) // Don't ignore terrain hits.
                                 {
                                     if (ProjectileUtils.IsIgnoredPart(hitPart)) continue; // Ignore ignored parts.
-                                    hitPartVelocity = hitPart.vessel.Velocity();
+                                    hitPartVelocity = hitPart.vessel.Velocity() - BDKrakensbane.FrameVelocityV3f;
                                 }
                                 break;
                             }


### PR DESCRIPTION
- Fix penetrated bullets using wrong velocity to decide when they're too slow.
- Fix NREs in RCSEngineControl due to destroyed engines.
- Fix laser hit offset for Krakensbane.