### PR TITLE
Oai rcs pr1

### DIFF
--- a/BDArmory/Control/BDModuleOrbitalAI.cs
+++ b/BDArmory/Control/BDModuleOrbitalAI.cs
@@ -1116,7 +1116,7 @@ namespace BDArmory.Control
             evadingGunfire = false;
 
             // Return if evading missile or ramming
-            if (currentStatusMode == StatusMode.Evading || currentStatusMode == StatusMode.Ramming)
+            if (weaponManager == null || currentStatusMode == StatusMode.Evading || currentStatusMode == StatusMode.Ramming)
             {
                 evasiveTimer = 0;
                 return;
@@ -1124,7 +1124,7 @@ namespace BDArmory.Control
 
             // Check if we should be evading gunfire, missile evasion is handled separately
             float threatRating = evasionThreshold + 1f; // Don't evade by default
-            if (weaponManager != null && weaponManager.underFire)
+            if (weaponManager.underFire)
             {
                 if (weaponManager.incomingMissTime >= evasionTimeThreshold && weaponManager.incomingThreatDistanceSqr >= evasionMinRangeThreshold * evasionMinRangeThreshold) // If we haven't been under fire long enough or they're too close, ignore gunfire
                     threatRating = weaponManager.incomingMissDistance;

--- a/BDArmory/Distribution/GameData/BDArmory/plot_summary.py
+++ b/BDArmory/Distribution/GameData/BDArmory/plot_summary.py
@@ -1,14 +1,15 @@
 #!/usr/bin/env python3
 
-# Standard library imports
+# Standard Library
 import argparse
 import csv
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
 from typing import Union
 
-# Third party imports
+# Third Party
 import matplotlib.pyplot as plt
 import numpy
 
@@ -63,5 +64,9 @@ if args.save:
         filename = args.save
     plt.savefig(filename, dpi='figure', bbox_inches='tight', transparent=args.transparent)
     print(f"Image saved to {filename}")
+    try:
+        subprocess.run(f'display {filename}'.split())
+    except:
+        pass
 else:
     plt.show(block=True)

--- a/BDArmory/GameModes/Asteroids.cs
+++ b/BDArmory/GameModes/Asteroids.cs
@@ -819,12 +819,7 @@ namespace BDArmory.GameModes
                         {
                             var relVel = asteroids[i].Velocity() - averageVelocity;
                             var relVelSqr = relVel.sqrMagnitude;
-                            if (relVelSqr < 2250000) // 1500^2
-                                force -= (0.1 + 4e-7 * relVelSqr) * relVel; // Reduce motion to average velocity of vessels (0.1 + 4e-7 v^2 should be stable below 1500m/s).
-                            else // Don't apply so much force as to yeet the asteroid (hopefully).
-                            {
-                                force -= relVel;
-                            }
+                            force -= Math.Min(0.1 + 4e-7 * relVelSqr, 1) * relVel; // Reduce motion to average velocity of vessels (0.1 + 4e-7 v^2 should be stable below 1500m/s).
                         }
                     }
                     else

--- a/BDArmory/GameModes/Asteroids.cs
+++ b/BDArmory/GameModes/Asteroids.cs
@@ -770,7 +770,8 @@ namespace BDArmory.GameModes
             Vector3 averagePosition;
             float factor = 0;
             float repulseTimer = Time.time;
-            float Rscale = 0.04f * radius * radius; // 20% of the field radius.
+            float radiusSqr = radius * radius;
+            float Rscale = 0.04f * radiusSqr; // 20% of the field radius.
             Vector3d rVelLimit = 1500 * Vector3d.one;
             while (floating)
             {
@@ -856,9 +857,9 @@ namespace BDArmory.GameModes
                         if (vesselCount > 0)
                         {
                             // Attract to vessel centroid if in the outer region (90%) of the asteroid field.
-                            if ((asteroids[i].transform.position - averagePosition).sqrMagnitude > 0.81f * radius * radius)
+                            if ((asteroids[i].transform.position - averagePosition).sqrMagnitude > 0.81f * radiusSqr)
                             {
-                                float centroidFactor = TimeWarp.CurrentRate * ((asteroids[i].transform.position - averagePosition).sqrMagnitude - 0.81f * radius * radius) * 5e-7f;
+                                float centroidFactor = TimeWarp.CurrentRate * Mathf.Min((asteroids[i].transform.position - averagePosition).sqrMagnitude - 0.81f * radiusSqr, radiusSqr) * 5e-7f;
                                 Vector3 radialDir = asteroids[i].transform.position - averagePosition;
                                 Vector3 radialVel = asteroids[i].Velocity() - averageVelocity;
                                 if (Vector3.Dot(radialDir, radialVel) < 0) centroidFactor *= 0.25f; // Less of a push when heading towards the centroid to avoid pinballing.

--- a/BDArmory/GameModes/Asteroids.cs
+++ b/BDArmory/GameModes/Asteroids.cs
@@ -823,7 +823,7 @@ namespace BDArmory.GameModes
                                 force -= (0.1 + 4e-7 * relVelSqr) * relVel; // Reduce motion to average velocity of vessels (0.1 + 4e-7 v^2 should be stable below 1500m/s).
                             else // Don't apply so much force as to yeet the asteroid (hopefully).
                             {
-                                force -= 2.8 * (relVel - rVelLimit) + rVelLimit;
+                                force -= relVel;
                             }
                         }
                     }

--- a/BDArmory/Modules/KerbalSafety.cs
+++ b/BDArmory/Modules/KerbalSafety.cs
@@ -278,7 +278,7 @@ namespace BDArmory.Modules
             }
             else
             {
-                if (fromTo.host != null && fromTo.host.loaded)
+                if (fromTo.host != null && fromTo.host.loaded && !GameModes.AsteroidUtils.IsManagedAsteroid(fromTo.host))
                 {
                     Debug.LogWarning("[BDArmory.KerbalSafety]: " + fromTo.host + " got eaten by the Kraken!");
                     fromTo.host.gameObject.SetActive(false);

--- a/BDArmory/VesselSpawning/SpawnUtils.cs
+++ b/BDArmory/VesselSpawning/SpawnUtils.cs
@@ -370,8 +370,7 @@ namespace BDArmory.VesselSpawning
             {
                 if (vessel.vesselType == VesselType.SpaceObject)
                 {
-                    if ((BDArmorySettings.ASTEROID_RAIN && AsteroidRain.IsManagedAsteroid(vessel))
-                        || (BDArmorySettings.ASTEROID_FIELD && AsteroidField.IsManagedAsteroid(vessel))) // Don't remove asteroids when we're using them.
+                    if (AsteroidUtils.IsManagedAsteroid(vessel)) // Don't remove asteroids when we're using them.
                     {
                         --removeVesselsPending;
                         yield break;


### PR DESCRIPTION
* If saving the plot summary to a file, show the image too.
* Limit motion-reduction force applied to asteroids to a linear function above 1500m/s to avoid yeeting them when the average velocity suddenly changes due to vessels dying.
* Limit the maximum centroidFactor for re-centering asteroids to avoid yeeting them when the centroid suddenly changes due to vessels dying.
* Avoid NRE if the WM gets destroyed while evading.
